### PR TITLE
Update R-Type Leo (Japan).mra

### DIFF
--- a/releases/_alternatives/_R-Type Leo/R-Type Leo (Japan).mra
+++ b/releases/_alternatives/_R-Type Leo/R-Type Leo (Japan).mra
@@ -12,7 +12,7 @@
     <players>2</players>
     <joystick>8-way</joystick>
     <num_buttons>2</num_buttons>
-    <buttons default="B,A,Start,Select" names="Fire,Psy-Bits Control,-,-,-,-,Start,Coin,P2 Start,Pause"></buttons>
+    <buttons default="B,A,Start,Select" names="Fire,-,-,-,-,-,Start,Coin,P2 Start,Pause"></buttons>
     <switches default="00 00 00">
         <dip bits="0,1" ids="3,2,4,5" name="Lives"></dip>
         <dip bits="2,3" ids="Normal,Easy,Hard,Very Easy" name="Difficulty"></dip>


### PR DESCRIPTION
Japanese rtype leo doesn't have a separate button for the psy bits. Instead, you're supposed to hold the button and release